### PR TITLE
Fix: Resolve Missing Constants Reference in Ready Hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cosmere-rpg-animated-weapons",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/module.json
+++ b/src/module.json
@@ -1,9 +1,9 @@
 {
 	"id": "cosmere-rpg-animated-weapons",
 	"title": "Cosmere RPG Animated Weapons",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"manifest": "https://github.com/RealMaelstrom/Cosmere-RPG-Animated-Weapons/releases/latest/download/module.json",
-	"download": "https://github.com/RealMaelstrom/Cosmere-RPG-Animated-Weapons/releases/download/1.1.0/Cosmere-rpg-animated-weapons-1.1.0.zip",
+	"download": "https://github.com/RealMaelstrom/Cosmere-RPG-Animated-Weapons/releases/download/1.1.1/Cosmere-rpg-animated-weapons-1.1.1.zip",
 	"compatibility": {
 		"minimum": "12",
 		"verified": "12"
@@ -53,7 +53,7 @@
 			}
 		]
 	},
-	"description": "Module containing compendium items that have animation macros tied to enable the use of animated weapon strikes. Uses the JB2A patreon animations for all currently available weapons in the Cosmere RPG.",
+	"description": "Module which applies animations from the JB2A library (free or premium, automatically detecting which is installed) to weapon usage.",
 	"authors": [
 		{
 			"name": "Maelstrom",

--- a/src/utils/version-parsing.js
+++ b/src/utils/version-parsing.js
@@ -1,3 +1,5 @@
+import { MODULE_ID, SETTINGS } from "../utils/constants";
+
 function SemanticVersioning(version) {
 	const splitVersion = version.split(".");
 	if (splitVersion.length < 3) {


### PR DESCRIPTION
Simple bugfix for an error in the 'ready' hook due to missing constants import. This also increments the version to 1.1.1 (for potential release) and updates the module description, because that was still outdated.